### PR TITLE
getTokenParsers, getNodeVisitors, getFunctions  might add "array" as …

### DIFF
--- a/src/EventListener/AddRequestFormatsListener.php
+++ b/src/EventListener/AddRequestFormatsListener.php
@@ -26,7 +26,7 @@ class AddRequestFormatsListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 1],

--- a/src/Twig/TwigSpreadsheetExtension.php
+++ b/src/Twig/TwigSpreadsheetExtension.php
@@ -47,7 +47,7 @@ class TwigSpreadsheetExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new \Twig_SimpleFunction('xlsmergestyles', [$this, 'mergeStyles']),
@@ -61,7 +61,7 @@ class TwigSpreadsheetExtension extends \Twig_Extension
      *
      * @throws \InvalidArgumentException
      */
-    public function getTokenParsers()
+    public function getTokenParsers(): array
     {
         return [
             new AlignmentTokenParser([], HeaderFooterWrapper::ALIGNMENT_CENTER),
@@ -80,7 +80,7 @@ class TwigSpreadsheetExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
-    public function getNodeVisitors()
+    public function getNodeVisitors(): array
     {
         return [
             new MacroContextNodeVisitor(),


### PR DESCRIPTION
…a native return type declaration in the future. Remove deprecation